### PR TITLE
fix: WPM playback speed and ETA accuracy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1060,8 +1060,12 @@ The goal is not to race through text, but to find your optimal pace where speed 
         const current = Math.min(idx + 1, total);
         elStatPos.textContent = total > 0 ? `${current} / ${total}` : "0 / 0";
 
-        const wordsLeft = Math.max(total - idx, 0);
-        const secondsLeft = Math.round((wordsLeft / wpm) * 60);
+        const baseDelay = 60000 / wpm;
+        let msLeft = 0;
+        for (let i = idx; i < total; i++) {
+          msLeft += getWordDelay(words[i], baseDelay);
+        }
+        const secondsLeft = Math.round(msLeft / 1000);
         const minutes = Math.floor(secondsLeft / 60);
         const seconds = secondsLeft % 60;
         elStatEta.textContent =
@@ -1129,6 +1133,19 @@ The goal is not to race through text, but to find your optimal pace where speed 
         wpm = Math.min(1000, Math.max(50, wpm + delta));
         elWpmNumber.textContent = wpm;
         showWpmPopup();
+        if (playing) {
+          if (speechEnabled && speechDriving) {
+            // Restart speech from current word with new rate
+            speechSynthesis.cancel();
+            speechDriving = false;
+            startSpeechDriven(idx > 0 ? idx - 1 : idx);
+          } else if (!speechEnabled && timer) {
+            // Reschedule next tick with updated WPM delay
+            clearTimeout(timer);
+            const delay = getWordDelay(words[idx], 60000 / wpm);
+            timer = setTimeout(tick, delay);
+          }
+        }
       }
 
       function showWpmPopup() {


### PR DESCRIPTION
## Summary
- **WPM changes now apply immediately** — `adjustWpm` reschedules the pending timer (or restarts the speech utterance) so playback speed updates in real-time
- **ETA is now accurate** — sums actual per-word adaptive delays (accounting for word length and punctuation multipliers) instead of naive `wordsLeft / wpm * 60`

## Test plan
- [x] Change WPM while playing (speech off) — speed changes immediately
- [x] Change WPM while playing (speech on) — speech restarts at new rate
- [x] ETA countdown matches actual elapsed time at various WPM settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/megabyte0x/stillreading/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
